### PR TITLE
Add support for Fusion COMMAND_STOP

### DIFF
--- a/DIYCNC_Common.js
+++ b/DIYCNC_Common.js
@@ -685,6 +685,9 @@ function onCommand(command) {
         return;
       currentFirmware.probeTool();
       return;
+    case COMMAND_STOP:
+      writeBlock(mFormat.format(0));
+      return;
   }
 }
 


### PR DESCRIPTION
For some workflows, it can be useful to be able to insert a manual stop into the gcode from Fusion360.  To give an example, here's a workflow I'm using to cut LowRider Y-plates without the need for tabs:

* Machine bores out all the holes in the plate
* Stop the machine
* Run fasteners through some of the holes
* Start the machine using the LCD
* Machine cuts the contours on the plate

Because the parts are now held in with fasteners, there is no need to use tabs and deal with the resulting tab cleanup.

![image](https://user-images.githubusercontent.com/557985/82760368-b259e300-9db8-11ea-8593-e09e818831fe.png)

I've done a few test runs with this change in place and it seems to correctly insert the `M0` command as expected.